### PR TITLE
test(tests/donor): adiciona testes para o serviço de doadores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2508,6 +2509,7 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",

--- a/src/tests/donor.test.js
+++ b/src/tests/donor.test.js
@@ -1,0 +1,88 @@
+import * as donorService from "../services/donor.service.js";
+
+// 🧪 Mock do Prisma Client
+jest.mock("@prisma/client", () => {
+  const mockDonor = {
+    create: jest.fn(),
+    findMany: jest.fn(),
+    findUnique: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+
+  return {
+    PrismaClient: jest.fn(() => ({
+      donor: mockDonor,
+    })),
+  };
+});
+
+describe("📦 Donor Service", () => {
+  const mockData = {
+    id: 1,
+    name: "Empresa X",
+    email: "empresa@example.com",
+    phone: "1234567890",
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  // 🆕 Teste de criação de doador
+  it("🆕 deve criar um novo doador", async () => {
+    const { PrismaClient } = await import("@prisma/client");
+    const prisma = new PrismaClient();
+    prisma.donor.create.mockResolvedValue(mockData);
+
+    const result = await donorService.createDonor(mockData);
+    expect(result).toEqual(mockData);
+    expect(prisma.donor.create).toHaveBeenCalledWith({ data: mockData });
+  });
+
+  // 📋 Teste para listar todos os doadores
+  it("📋 deve retornar todos os doadores", async () => {
+    const { PrismaClient } = await import("@prisma/client");
+    const prisma = new PrismaClient();
+    prisma.donor.findMany.mockResolvedValue([mockData]);
+
+    const result = await donorService.getAllDonors();
+    expect(result).toEqual([mockData]);
+    expect(prisma.donor.findMany).toHaveBeenCalled();
+  });
+
+  // 🔍 Teste para buscar doador por ID
+  it("🔍 deve retornar um doador por ID", async () => {
+    const { PrismaClient } = await import("@prisma/client");
+    const prisma = new PrismaClient();
+    prisma.donor.findUnique.mockResolvedValue(mockData);
+
+    const result = await donorService.getDonorById("1");
+    expect(result).toEqual(mockData);
+    expect(prisma.donor.findUnique).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  // 🔄 Teste de atualização de doador
+  it("🔄 deve atualizar um doador por ID", async () => {
+    const updatedData = { ...mockData, name: "Empresa Y" };
+    const { PrismaClient } = await import("@prisma/client");
+    const prisma = new PrismaClient();
+    prisma.donor.update.mockResolvedValue(updatedData);
+
+    const result = await donorService.updateDonor("1", { name: "Empresa Y" });
+    expect(result.name).toBe("Empresa Y");
+    expect(prisma.donor.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: expect.objectContaining({ name: "Empresa Y" }),
+    });
+  });
+
+  // ❌ Teste de exclusão de doador
+  it("❌ deve deletar um doador por ID", async () => {
+    const { PrismaClient } = await import("@prisma/client");
+    const prisma = new PrismaClient();
+    prisma.donor.delete.mockResolvedValue(mockData);
+
+    const result = await donorService.deleteDonor("1");
+    expect(result).toEqual(mockData);
+    expect(prisma.donor.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+});


### PR DESCRIPTION
Adição de Testes para o Serviço de Doadores 🚀

Essa pull request contém a implementação dos testes para o serviço de doadores. Os principais pontos abordados são:

Criação de novos doadores: Testes para garantir que o processo de criação de doadores funciona corretamente com dados válidos.

Listagem de doadores: Testes para verificar que a listagem de doadores está retornando os dados esperados.

Busca por ID de doador: Verificação se a busca por ID retorna corretamente os dados de um doador específico.

Atualização de doadores: Testes para garantir que os dados dos doadores são atualizados corretamente.

Exclusão de doadores: Testes para verificar se a exclusão de doadores funciona conforme esperado.

Esses testes visam garantir que o serviço de doadores esteja funcionando de acordo com os requisitos e evitar regressões no futuro.